### PR TITLE
remove the static members from the generation file

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -22,9 +22,12 @@ class SerializableGenerator extends GeneratorForAnnotation<Serializable> {
     var className = element.name;
     var fields = _distinctByName(element.fields.toList()..addAll(stFields));
     var accessors = _distinctByName<PropertyAccessorElement>(element.accessors.toList()..addAll(stAccessors));
-    var getters = _distinctByName<PropertyAccessorElement>(accessors.where((a) => a.kind == ElementKind.GETTER));
-    var setters = _distinctByName<PropertyAccessorElement>(accessors.where((a) => a.kind == ElementKind.SETTER));
-    var methods = _distinctByName<MethodElement>(element.methods.toList()..addAll(stMethods));
+    var getters = _distinctByName<PropertyAccessorElement>(
+      accessors.where((a) => a.kind == ElementKind.GETTER && !a.isStatic));
+    var setters = _distinctByName<PropertyAccessorElement>(
+      accessors.where((a) => a.kind == ElementKind.SETTER && !a.isStatic));
+    var methods = _distinctByName<MethodElement>(
+      element.methods.where((MethodElement e) => !e.isStatic).toList()..addAll(stMethods));
 
 
 


### PR DESCRIPTION
```
static final Map<String, SimpleType> list = {
    'minutes': new SimpleType('58c42d14f17f33ec6e2020ad', 'minutes'),
    'hours': new SimpleType('58c42d26f17f33ec6e2020ae', 'hours'),
    'percent': new SimpleType('58c42d4bf17f33ec6e2020b3', 'percent')
  };
```

the serializable is printing: 

`Map<String, SimpleType> get list;`

Thus, throwing the error: The name 'list' is already defined within file.g.dart.

The static methods and properties should not be within the generated file.